### PR TITLE
fix: cannot tokenize a string contains any spaces (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - (nothing to record here)
 
+## [0.1.4] - 2021-05-23
+### Fixed
+- Fix issue #7: cannot tokenize a string contains any spaces.
+
 ## [0.1.3] - 2021-05-15
 ### Added
 - Add `Lexer#skip_token(offset)`

--- a/lib/rbscmlex.rb
+++ b/lib/rbscmlex.rb
@@ -5,4 +5,9 @@ module Rbscmlex
   require_relative "rbscmlex/token"
   require_relative "rbscmlex/lexer"
   require_relative "rbscmlex/version"
+
+  def self.lexer(source)
+    Lexer.new(source)
+  end
+
 end

--- a/lib/rbscmlex/version.rb
+++ b/lib/rbscmlex/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Rbscmlex
-  VERSION = "0.1.3"
-  RELEASE = "2021-05-15"
+  VERSION = "0.1.4"
+  RELEASE = "2021-05-23"
 end

--- a/test/rbscmlex_lexer_test.rb
+++ b/test/rbscmlex_lexer_test.rb
@@ -4,6 +4,16 @@ require "test_helper"
 
 class RbscmlexLexerTest < Minitest::Test
 
+  # issue #7
+
+  def test_it_can_tokenize_a_string_contains_spaces
+    input = '" a string contains some spaces "'
+    l = Rbscmlex::Lexer.new(input)
+    type, literal = *l.peek_token
+    assert_equal :string, type
+    assert_equal input, literal
+  end
+
   # issue #5
 
   def test_it_can_retrieve_token_with_specifying_offset


### PR DESCRIPTION
- add a test to reproduce the symptom
- add a private method `Lexer#split_as_space(source)` to split an
  argument at space considering enclosing with double quotation
- also add a module function, `Rbscmlex.lexer(source)` to instantiate
  Lexer
- bump version: 0.1.3 -> 0.1.4

This PR will fix #7.